### PR TITLE
formatting: no linebreak between empty {}

### DIFF
--- a/src/kotlin/org/intellij/plugins/hcl/formatter/HCLFormattingBuilderModel.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/formatter/HCLFormattingBuilderModel.kt
@@ -44,6 +44,7 @@ open class HCLFormattingBuilderModel(val language: Language = HCLLanguage) : For
         .after(EQUALS).spacing(spacesAroundAssignment, spacesAroundAssignment, 0, false, 0)
         .afterInside(IDENTIFIER, BLOCK).spaces(1)
         .afterInside(STRING_LITERAL, BLOCK).spaces(1)
+        .between(L_CURLY, R_CURLY).none()
         .withinPairInside(L_CURLY, R_CURLY, OBJECT).lineBreakInCode()
         .withinPair(L_BRACKET, R_BRACKET).spaceIf(commonSettings.SPACE_WITHIN_BRACKETS) //, true
         .withinPair(L_CURLY, R_CURLY).spaceIf(commonSettings.SPACE_WITHIN_BRACES) //, true

--- a/test/org/intellij/plugins/hcl/HCLFormatterTest.java
+++ b/test/org/intellij/plugins/hcl/HCLFormatterTest.java
@@ -76,13 +76,15 @@ public class HCLFormatterTest extends LightCodeInsightFixtureTestCase {
   public void testFormatBlock_Brace() throws Exception {
     doSimpleTest("a b c {\n  a = true}", "a b c {\n  a = true\n}");
     doSimpleTest("block x {a=true}", "block x {\n  a = true\n}");
-    doSimpleTest("block x {}", "block x {\n}");
+    doSimpleTest("block x {}", "block x {}");
+    doSimpleTest("block x {\n}", "block x {\n}");
   }
 
   @Test
   public void testFormatBlock_Space() throws Exception {
-    doSimpleTest("block x{}", "block x {\n}");
-    doSimpleTest("block 'x'{}", "block 'x' {\n}");
+    doSimpleTest("block x{}", "block x {}");
+    doSimpleTest("block 'x'{}", "block 'x' {}");
+    doSimpleTest("block 'x'{\n}", "block 'x' {\n}");
     doSimpleTest("block x{a=true}", "block x {\n  a = true\n}");
   }
 


### PR DESCRIPTION
Hey!

Thanks for awesome plugin :) 

We are going to adopt `terraform fmt` in our project and it would be great if we were able to set up the formatting in the same way as `fmt` behaves.

This change mimics the `fmt` behaviour when there is nothing between c-brackets, e.g. `variable "name" {}` will not be changed. What do you think?
