### PR TITLE
Add comment character to be chosen based on developers preferences

### DIFF
--- a/src/java/org/intellij/plugins/hcl/formatter/HCLCodeStyleSettings.java
+++ b/src/java/org/intellij/plugins/hcl/formatter/HCLCodeStyleSettings.java
@@ -26,6 +26,7 @@ import org.jetbrains.annotations.NotNull;
  */
 public class HCLCodeStyleSettings extends CustomCodeStyleSettings {
 
+  // Format alignment properties
   public static int DO_NOT_ALIGN_PROPERTY = PropertyAlignment.DO_NOT_ALIGN.getId();
   public static int ALIGN_PROPERTY_ON_VALUE = PropertyAlignment.ALIGN_ON_VALUE.getId();
   public static int ALIGN_PROPERTY_ON_EQUALS = PropertyAlignment.ALIGN_ON_EQUALS.getId();
@@ -40,6 +41,10 @@ public class HCLCodeStyleSettings extends CustomCodeStyleSettings {
    */
   public int PROPERTY_ALIGNMENT = PropertyAlignment.DO_NOT_ALIGN.getId();
 
+  // Commenter properties
+  public int PROPERTY_LINE_COMMENTER_CHARACTER = LineCommenterCharacter.LINE_DOUBLE_SLASHES.getId();
+
+  // Misc
   public int OBJECT_WRAPPING = CommonCodeStyleSettings.WRAP_ALWAYS;
   // This was default policy for array elements wrapping in JavaScript's JSON.
   // CHOP_DOWN_IF_LONG seems more appropriate however for short arrays.
@@ -49,6 +54,7 @@ public class HCLCodeStyleSettings extends CustomCodeStyleSettings {
     super(language.getID(), container);
   }
 
+  // Enums  - Format alignment
   public enum PropertyAlignment {
     DO_NOT_ALIGN("Do not align", 0),
     ALIGN_ON_VALUE("On value", 1),
@@ -58,6 +64,29 @@ public class HCLCodeStyleSettings extends CustomCodeStyleSettings {
     private final int myId;
 
     PropertyAlignment(@NotNull String description, int id) {
+      myDescription = description;
+      myId = id;
+    }
+
+    @NotNull
+    public String getDescription() {
+      return myDescription;
+    }
+
+    public int getId() {
+      return myId;
+    }
+  }
+
+  // Enums  - Line Commenter Character
+  public enum LineCommenterCharacter {
+    LINE_DOUBLE_SLASHES("Double Slashes (//)", 0),
+    LINE_POUND_SIGN("Pound Sign (#)", 1),;
+
+    private final String myDescription;
+    private final int myId;
+
+    LineCommenterCharacter(@NotNull String description, int id) {
       myDescription = description;
       myId = id;
     }

--- a/src/kotlin/org/intellij/plugins/hcl/editor/HCLCommenter.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/editor/HCLCommenter.kt
@@ -16,11 +16,25 @@
 package org.intellij.plugins.hcl.editor
 
 import com.intellij.lang.Commenter
+import com.intellij.psi.codeStyle.CodeStyleSettingsManager
+import org.intellij.plugins.hcl.formatter.HCLCodeStyleSettings
+import kotlin.properties.Delegates
 
 
 class HCLCommenter : Commenter {
+
+  private var customSettings : HCLCodeStyleSettings by Delegates.notNull()
+
+  init {
+    customSettings = CodeStyleSettingsManager.getInstance().
+        currentSettings.getCustomSettings(HCLCodeStyleSettings::class.java)
+  }
+
   override fun getLineCommentPrefix(): String? {
-    return "//"
+    return when (HCLCodeStyleSettings.LineCommenterCharacter.values()[customSettings.PROPERTY_LINE_COMMENTER_CHARACTER]){
+      HCLCodeStyleSettings.LineCommenterCharacter.LINE_DOUBLE_SLASHES -> "//"
+      HCLCodeStyleSettings.LineCommenterCharacter.LINE_POUND_SIGN -> "#"
+    }
   }
 
   override fun getBlockCommentPrefix(): String? {

--- a/src/kotlin/org/intellij/plugins/hcl/formatter/HCLCodeStylePanel.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/formatter/HCLCodeStylePanel.kt
@@ -30,14 +30,26 @@ class HCLCodeStylePanel(private val language: Language, settings: CodeStyleSetti
   }
 
   override fun initTables() {
-    val values = HCLCodeStyleSettings.PropertyAlignment.values()
-    val strings = arrayOfNulls<String>(values.size)
-    val ints = IntArray(values.size)
-    for (i in values.indices) {
-      strings[i] = values[i].description
-      ints[i] = values[i].id
+    // Format alignment
+    val alignment_values = HCLCodeStyleSettings.PropertyAlignment.values()
+    val alignment_strings = arrayOfNulls<String>(alignment_values.size)
+    val alignment_ints = IntArray(alignment_values.size)
+    for (i in alignment_values.indices) {
+      alignment_strings[i] = alignment_values[i].description
+      alignment_ints[i] = alignment_values[i].id
     }
-    showCustomOption(HCLCodeStyleSettings::class.java, "PROPERTY_ALIGNMENT", "Align properties", "Formatting options", strings, ints)
+
+    // Line Commenter character
+    val linecommenterchar_values = HCLCodeStyleSettings.LineCommenterCharacter.values()
+    val linecommenterchar_strings = arrayOfNulls<String>(linecommenterchar_values.size)
+    val linecommenterchar_ints = IntArray(linecommenterchar_values.size)
+    for (i in linecommenterchar_values.indices) {
+      linecommenterchar_strings[i] = linecommenterchar_values[i].description
+      linecommenterchar_ints[i] = linecommenterchar_values[i].id
+    }
+
+    showCustomOption(HCLCodeStyleSettings::class.java, "PROPERTY_ALIGNMENT", "Align properties", "Formatting options", alignment_strings, alignment_ints)
+    showCustomOption(HCLCodeStyleSettings::class.java, "PROPERTY_LINE_COMMENTER_CHARACTER", "Line Commenter Character", "Code conventions", linecommenterchar_strings, linecommenterchar_ints)
   }
 
   override fun getSettingsType(): LanguageCodeStyleSettingsProvider.SettingsType {


### PR DESCRIPTION
This PR addresses this issue #81 

First of all, congratulations for this great plugin. I have been using it for a while now and it's, hands down, the most comprehensive HCL plugin so far.

As the commenter character can be either ```#``` or ```//```, it becomes a matter of choice and the option should be given to developers to choose based on their preferences/beliefs/agreed best practices.

I created an additional custom config item within the CodeStyle panel which allows developers to choose between ```#``` and ```//``` as the line commenter character. To ensure backwards compatibility, ```//``` is used by default. 

Here are a few screenshots of the proposed change in action.

<img width="1040" alt="screen shot 2017-11-15 at 4 30 50 pm" src="https://user-images.githubusercontent.com/1011868/32817629-be12faee-ca23-11e7-88a9-bd590fb9689a.png">
<img width="503" alt="screen shot 2017-11-15 at 4 32 21 pm" src="https://user-images.githubusercontent.com/1011868/32817636-c206610e-ca23-11e7-9d5d-c839eaf0ba57.png">
<img width="528" alt="screen shot 2017-11-15 at 4 31 59 pm" src="https://user-images.githubusercontent.com/1011868/32817638-c3ac1152-ca23-11e7-85a6-d5815fb44e2b.png">

If you think this is a good contribution to your plugin, please accept this PR.

Best regards,

Paulo Almeida