### PR TITLE
Make attribute "linux_profile" optional in azurerm_kubernetes_cluster

### DIFF
--- a/res/terraform/model/providers/azurerm.json
+++ b/res/terraform/model/providers/azurerm.json
@@ -4399,7 +4399,7 @@
       },
       "linux_profile": {
         "Type": "List",
-        "Required": true,
+        "Required": false,
         "MaxItems": 1,
         "Elem": {
           "Type": "SchemaInfo",


### PR DESCRIPTION
The attribute "linux_profile" is actually optional in azurerm_kubernetes_cluster, see: https://www.terraform.io/docs/providers/azurerm/r/kubernetes_cluster.html.