### PR TITLE
Fix not finding .terraform dir in some circumstances (another attempt to solve some of #170)

### DIFF
--- a/src/kotlin/org/intellij/plugins/hcl/terraform/config/DotTerraformUtil.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/terraform/config/DotTerraformUtil.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.intellij.plugins.hcl.terraform.config
+
+import com.intellij.openapi.roots.ProjectFileIndex
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.psi.PsiDirectory
+import com.intellij.psi.util.CachedValueProvider
+import com.intellij.psi.util.CachedValuesManager
+
+object DotTerraformUtil {
+
+  fun findTerraformDir(searchFrom: PsiDirectory) = CachedValuesManager.getCachedValue(searchFrom, TerraformDirCachedValueProvider(searchFrom))
+
+  class TerraformDirCachedValueProvider(private val searchFrom: PsiDirectory) : CachedValueProvider<VirtualFile?> {
+    override fun compute(): CachedValueProvider.Result<VirtualFile?>? {
+      // Includes as dependency items the chain of PsiDirectory objects that were searched so that a .terraform dir added higher up the
+      // chain will invalidate the cached result.
+      //
+      // PsiDirectory objects become "out of date" more than strictly necessary for our purpose here.  The only alternative I've thought of
+      // is depending on the VirtualFile for each dir but those do not become out of date when a file is added (!?) so cannot help here.
+
+      val projectfileIndex = ProjectFileIndex.SERVICE.getInstance(searchFrom.project)
+      val dependencies = mutableListOf<Any>()
+      var lookIn: PsiDirectory? = searchFrom
+
+      while (lookIn != null && projectfileIndex.isInContent(lookIn.virtualFile)) {
+        dependencies.add(lookIn)
+        val found = lookIn.findSubdirectory(".terraform")
+        if (found != null) {
+          dependencies.add(found)
+          return CachedValueProvider.Result(found.virtualFile, *dependencies.toTypedArray())
+        }
+        lookIn = lookIn.parent
+      }
+      return CachedValueProvider.Result(null, *dependencies.toTypedArray())
+    }
+  }
+}

--- a/test/org/intellij/plugins/hcl/terraform/config/DotTerraformUtilTest.kt
+++ b/test/org/intellij/plugins/hcl/terraform/config/DotTerraformUtilTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.intellij.plugins.hcl.terraform.config
+
+import com.intellij.testFramework.deleteFile
+import com.intellij.testFramework.fixtures.CodeInsightFixtureTestCase
+import com.intellij.testFramework.fixtures.impl.IdeaTestFixtureFactoryImpl
+import junit.framework.TestCase
+
+class DotTerraformUtilTest : CodeInsightFixtureTestCase<IdeaTestFixtureFactoryImpl.MyEmptyModuleFixtureBuilderImpl>() {
+
+  fun testNone() {
+    TestCase.assertNull(doFind("/"))
+  }
+
+  fun testItsAFile() {
+    myFixture.tempDirFixture.createFile("/.terraform")
+    TestCase.assertNull(doFind("/"))
+  }
+
+  fun testInSameDir() {
+    val path = "/.terraform"
+    findOrCreateDir(path)
+    checkFind("/", path)
+  }
+
+  fun testInParentDir() {
+    val path = "/.terraform"
+    findOrCreateDir(path)
+    checkFind("/a", path)
+  }
+
+  fun testCreatedThenDeleted() {
+    val path1 = "/.terraform"
+    val path2 = "/a/.terraform"
+    val path3 = "/a/b/c/d/.terraform"
+    val searchFrom = "/a/b/c/d"
+
+    val dir1 = findOrCreateDir(path1)
+    checkFind(searchFrom, path1)
+
+    val dir2 = findOrCreateDir(path2)
+    checkFind(searchFrom, path2)
+
+    val dir3 = findOrCreateDir(path3)
+    checkFind(searchFrom, path3)
+
+    deleteFile(dir3.virtualFile)
+    checkFind(searchFrom, path2)
+
+    val dir3b = findOrCreateDir(path3)
+    checkFind(searchFrom, path3)
+
+    deleteFile(dir3b.virtualFile)
+    deleteFile(dir2.virtualFile)
+    checkFind(searchFrom, path1)
+
+    deleteFile(dir1.virtualFile)
+    TestCase.assertNull(doFind(searchFrom))
+  }
+
+  private fun doFind(searchFrom: String) =
+      DotTerraformUtil.findTerraformDir(findOrCreateDir(searchFrom))
+
+  private fun checkFind(searchFrom: String, expected: String) =
+      TestCase.assertEquals("${myFixture.tempDirPath}$expected", doFind(searchFrom)?.path)
+
+  private fun findOrCreateDir(path: String) =
+      myFixture.psiManager.findDirectory(myFixture.tempDirFixture.findOrCreateDir(path))!!
+}


### PR DESCRIPTION
Added unit tests and moved the finding function to a new class because it felt wrong making `ModuleDetectionUtil.getTerraformDirSomewhere()` more visible just to test it.

Changed to use `ProjectFileIndex.isInContent()` instead of `VfsUtilCore.isAncestor(project.baseDir, ...)` because the later was causing trouble due to the dir structure of some of my TF projects.

Added caching to the finding function.