### PR TITLE
"Show Terraform Documentation" intentionAction

### DIFF
--- a/res/META-INF/plugin.xml
+++ b/res/META-INF/plugin.xml
@@ -241,6 +241,10 @@
                      groupKey="terraform.files.inspection.group.display.name" enabledByDefault="true" level="ERROR"
                      implementationClass="org.intellij.plugins.hil.inspection.HILOperationTypesMismatchInspection"/>
 
+    <intentionAction>
+      <className>org.intellij.plugins.hcl.codeinsight.ShowDocumentationIntentionAction</className>
+    </intentionAction>
+
     <!-- Terraform as Tool -->
     <projectService serviceImplementation="org.intellij.plugins.hcl.terraform.TerraformToolProjectSettings"/>
     <projectConfigurable groupId="tools" instance="org.intellij.plugins.hcl.terraform.TerraformToolConfigurable"

--- a/src/kotlin/org/intellij/plugins/hcl/codeinsight/ShowDocumentationIntentionAction.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/codeinsight/ShowDocumentationIntentionAction.kt
@@ -35,13 +35,13 @@ class ShowDocumentationIntentionAction : BaseIntentionAction(), LowPriorityActio
     return "https://www.terraform.io/docs/providers/$provider/$resource/$id.html"
   }
 
-  override fun getText(): String {
-    return "Show Terraform documentation"
-  }
+  override fun getText() = "Show Terraform documentation"
 
   override fun getFamilyName() = text
 
   override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = findElements(editor, file) != null
+
+  override fun startInWriteAction() = false
 
   override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
     val (identifier, value) = findElements(editor, file) ?: return

--- a/src/kotlin/org/intellij/plugins/hcl/codeinsight/ShowDocumentationIntentionAction.kt
+++ b/src/kotlin/org/intellij/plugins/hcl/codeinsight/ShowDocumentationIntentionAction.kt
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2000-2019 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.intellij.plugins.hcl.codeinsight
+
+import com.intellij.codeInsight.intention.LowPriorityAction
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.ide.BrowserUtil
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import org.intellij.plugins.hcl.psi.HCLBlock
+import org.intellij.plugins.hcl.psi.HCLIdentifier
+import org.intellij.plugins.hcl.psi.HCLStringLiteral
+
+class ShowDocumentationIntentionAction : BaseIntentionAction(), LowPriorityAction {
+  private val supportedIdentifiers = arrayOf("resource", "data")
+
+  private fun url(identifier: String, element: String): String {
+    val resource = identifier[0]
+    val (provider, id) = element.trim('"').split("_", limit = 2)
+    return "https://www.terraform.io/docs/providers/$provider/$resource/$id.html"
+  }
+
+  override fun getText(): String {
+    return "Show Terraform documentation"
+  }
+
+  override fun getFamilyName() = text
+
+  override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean = findElements(editor, file) != null
+
+  override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+    val (identifier, value) = findElements(editor, file) ?: return
+    BrowserUtil.browse(url(identifier, value))
+  }
+
+  private fun findElements(editor: Editor?, file: PsiFile?): Pair<String, String>? {
+    if (editor == null || file == null) {
+      return null
+    }
+
+    val element = PsiTreeUtil.findElementOfClassAtOffset(file, editor.caretModel.offset, HCLStringLiteral::class.java, false) ?: return null
+    val identifier = PsiTreeUtil.getPrevSiblingOfType(element, HCLIdentifier::class.java) ?: return null
+
+    return when {
+      element.parent is HCLBlock && identifier.text in supportedIdentifiers -> identifier.text to element.text
+      else -> null
+    }
+  }
+}


### PR DESCRIPTION
This feature implementation introduces an intentionAction attached to the `HCLStringLiteral`s Psi elements that are preceded by `HCLIdentifier` with `resource` or `data` text values.
Above matching elements get the `IntentionAction` with **Show Terraform Documentation** label.
Invoking this action opens an URL to the Terraform documentation in the browser.

Example:

![image](https://user-images.githubusercontent.com/108333/59012326-82c46a80-8837-11e9-964a-7ac1bbdd65ca.png)

```hcl
resource "aws_acm_certificate_validation" "default" {
  certificate_arn = "foo"
}
```

links to the https://www.terraform.io/docs/providers/aws/r/acm_certificate_validation.html

URL generator supports dynamic provider, **r**esource/**d**ata and identifier.