### PR TITLE
Moving over to the terraform plugin SDK.

### DIFF
--- a/schemas-extractor/.gitignore
+++ b/schemas-extractor/.gitignore
@@ -2,3 +2,4 @@ schemas
 providers.list
 providers.list.full
 failure.txt
+generate-schema/

--- a/schemas-extractor/template/generate-schema.go
+++ b/schemas-extractor/template/generate-schema.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/hashicorp/terraform/helper/schema"
-	tf "github.com/hashicorp/terraform/terraform"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	tf "github.com/hashicorp/terraform-plugin-sdk/terraform"
 	"github.com/terraform-providers/__FULL_NAME__/__NAME__"
 
 	"encoding/json"


### PR DESCRIPTION
This moves the generate schema script over to the Terrafrom plugin SDK.

This is required as most of the active providers have now moved over and
the script will not work with the providers that have migrated without
the script also migrating to the SDK.

Also adding the script template dir to the git ignore.